### PR TITLE
✨ feat: add new classes for rendering lists, list elements

### DIFF
--- a/src/Render/ListEle.php
+++ b/src/Render/ListEle.php
@@ -1,0 +1,47 @@
+<?php
+namespace ClimbUI\Render;
+
+require_once __DIR__ . '/../../support/lib/vendor/autoload.php';
+
+use \Approach\Render\HTML;
+use \Approach\Render\Node;
+use \Approach\Render\Stream;
+use \Approach\Render\Attribute;
+use \Stringable;
+
+class ListEle extends HTML{
+    public function __construct(
+        // Passing in Visual creates a sort of heirarchy that can be used to create a visual representation of the list
+        public null|string|Stringable $visual = null,
+    
+        public null|bool $isControl = false,
+
+        public null|string|Stringable $id = null,
+        null|string|array|Node|Attribute $classes = null,
+        public null|array|Attribute $attributes = new Attribute,
+        public null|string|Stringable|Stream|self $content = null,
+        public array $styles = [],
+        public bool $prerender = false,
+        public bool $selfContained = false,
+    ){
+        $ul = new HTML(tag: 'ul', classes: ['controls']);
+
+        if($this->isControl){
+            if($classes == null){
+                $classes = [];
+            }
+            $classes = array_merge($classes, ['control']);
+        }
+
+        parent::__construct(
+            tag: 'li',
+            id: $id,
+            classes: $classes,
+            attributes: $attributes,
+            styles: $styles,
+            content: ($visual ? $visual : null) . $ul . $content,
+            prerender: $prerender,
+            selfContained: $selfContained
+        );
+    }
+} 

--- a/src/Render/Pearl.php
+++ b/src/Render/Pearl.php
@@ -1,0 +1,42 @@
+<?php
+namespace ClimbUI\Render;
+
+require_once __DIR__ . '/../../support/lib/vendor/autoload.php';
+
+use \Approach\Render\HTML;
+use \Approach\Render\Node;
+use \Approach\Render\Stream;
+use \Approach\Render\Attribute;
+use \Stringable;
+
+class Pearl extends HTML{
+    public function __construct(
+        // Again, passing in the lists and the visual creates a nodal heirarchy
+        public null|string|Stringable $visual = null,
+        public null|array|Node $lists = null,
+
+        public null|string|Stringable $id = null,
+        null|string|array|Node|Attribute $classes = null,
+        public null|array|Attribute $attributes = new Attribute,
+        public null|string|Stringable|Stream|self $content = null,
+        public array $styles = [],
+        public bool $prerender = false,
+        public bool $selfContained = false,
+    ){
+        $ele = null;
+        foreach($lists as $list){
+            $ele .= $list;
+        }
+
+        parent::__construct(
+            tag: 'ul',
+            id: $id,
+            classes: $classes,
+            attributes: $attributes,
+            styles: $styles,
+            content: ($visual ? $visual : null) . $ele . $content,
+            prerender: $prerender,
+            selfContained: $selfContained
+        );
+    }
+} 

--- a/src/Render/Visual.php
+++ b/src/Render/Visual.php
@@ -1,0 +1,46 @@
+<?php
+namespace ClimbUI\Render;
+
+require_once __DIR__ . '/../../support/lib/vendor/autoload.php';
+
+use \Approach\Render\HTML;
+use \Approach\Render\Node;
+use \Approach\Render\Stream;
+use \Approach\Render\Attribute;
+use \Stringable;
+
+class Visual extends HTML{
+    public function __construct(
+        public null|string|Stringable $title = null,
+        public null|bool $isTodo = false,
+        public null|string|Stringable $id = null,
+        null|string|array|Node|Attribute $classes = null,
+        public null|array|Attribute $attributes = new Attribute,
+        public null|string|Stringable|Stream|self $content = null,
+        public array $styles = [],
+        public bool $prerender = false,
+        public bool $selfContained = false,
+    ){
+        //add .visual class to the classes array
+        //make sure classes is not null
+        if($classes === null){
+            $classes = [];
+        }
+        $classes = array_merge($classes, [' visual']);
+
+        $icon = new HTML('i', classes: ['icon ', 'bi ', 'bi-list-check']);
+        $label = new HTML('label', content: 'Procedures');
+        $expand = new HTML('i', classes: ['expand ', 'fa ', 'fa-angle-right']);
+
+        parent::__construct(
+            tag: 'div',
+            id: $id,
+            classes: $classes,
+            attributes: $attributes,
+            content: $icon . $label . $expand . $content,
+            styles: $styles,
+            prerender: $prerender,
+            selfContained: $selfContained
+        );
+    }
+} 


### PR DESCRIPTION
The changes introduce three new classes in the ClimbUI\Render namespace: Pearl, ListEle, and Visual. These classes are used for rendering different elements in the ClimbUI framework.

The Pearl class represents an unordered list (ul) element with optional visual and list content. It accepts parameters for visual, lists, id, classes, attributes, content, styles, prerender, and selfContained.

The ListEle class represents a list element (li) with optional visual and control properties. It accepts parameters for visual, isControl, id, classes, attributes, content, styles, prerender, and selfContained.

The Visual class represents a visual element with optional title and isTodo properties. It accepts parameters for title, isTodo, id, classes, attributes, content, styles, prerender, and selfContained.

These new classes provide more flexibility and customization options for rendering elements in